### PR TITLE
fix: nocopy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ module.exports = (buf) => {
   while (buf.length > 0) {
     const num = varint.decode(buf)
     result.push(num)
-    buf = buf.slice(varint.decode.bytes)
+    buf = buf.subarray(varint.decode.bytes)
   }
 
   return result


### PR DESCRIPTION
.slice() does a memcopy in Uint8Array, which is one perf difference we should be aware of when moving off of Node.js Buffer which doesn’t.